### PR TITLE
Add support for custom pwa elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@capacitor/cli": "^3.6.0",
     "@capacitor/core": "^3.6.0",
     "@ionic/cli": "^6.20.1",
+    "@ionic/pwa-elements": "^3.1.1",
     "@ionic/vue": "^6.1.11",
     "@ionic/vue-router": "^6.1.11",
     "@kevinmarrec/nuxt-pwa": "^0.3.0",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,6 +3,11 @@ import { defineNuxtConfig } from 'nuxt'
 export default defineNuxtConfig({
   modules: ['nuxt-ionic'],
   ionic: {
+    integrations: {
+      pwa: {
+        enableElements: true,
+      },
+    },
     // integrations: {
     //   meta: true,
     //   pwa: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ importers:
       '@capacitor/cli': ^3.6.0
       '@capacitor/core': ^3.6.0
       '@ionic/cli': ^6.20.1
+      '@ionic/pwa-elements': ^3.1.1
       '@ionic/vue': ^6.1.11
       '@ionic/vue-router': ^6.1.11
       '@kevinmarrec/nuxt-pwa': ^0.3.0
@@ -43,6 +44,7 @@ importers:
       '@capacitor/cli': 3.6.0
       '@capacitor/core': 3.6.0
       '@ionic/cli': 6.20.1
+      '@ionic/pwa-elements': 3.1.1
       '@ionic/vue': 6.1.11
       '@ionic/vue-router': 6.1.11
       '@kevinmarrec/nuxt-pwa': 0.3.0
@@ -659,6 +661,10 @@ packages:
       '@stencil/core': 2.17.0
       ionicons: 6.0.2
       tslib: 2.4.0
+    dev: false
+
+  /@ionic/pwa-elements/3.1.1:
+    resolution: {integrity: sha512-BoEX1pSrKn5dP4VQwaf8DweAmT4ynmpW+9f6oj/W1xLe54bmuXcUY07ziuZX1DLu50xHSYcO5qJ/dbYC/w6wgA==}
     dev: false
 
   /@ionic/utils-array/2.1.5:

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,10 +12,14 @@ import { setupMeta } from './parts/meta'
 import { setupPWA } from './parts/pwa'
 import { setupRouter } from './parts/router'
 
+interface PwaOptions {
+  enableElements?: boolean
+}
+
 export interface ModuleOptions {
   integrations?: {
     router?: boolean
-    pwa?: boolean
+    pwa?: boolean | PwaOptions
     meta?: boolean
   }
   css?: {
@@ -33,7 +37,9 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     integrations: {
       meta: true,
-      pwa: true,
+      pwa: {
+        enableElements: false,
+      },
       router: true,
     },
     css: {
@@ -108,6 +114,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (options.integrations?.pwa) {
       await setupPWA()
+
+      // If it isn't true, it must be a PWA options object
+      if (options.integrations.pwa != true && options.integrations.pwa?.enableElements) {
+        addPlugin(resolve(runtimeDir, 'customElements.client'))
+      }
     }
 
     // Set up Ionic Router integration

--- a/src/runtime/customElements.client.ts
+++ b/src/runtime/customElements.client.ts
@@ -1,0 +1,6 @@
+import { defineCustomElements } from '@ionic/pwa-elements/loader'
+import { defineNuxtPlugin } from '#imports'
+
+export default defineNuxtPlugin(() => {
+  defineCustomElements(window)
+})

--- a/src/runtime/customElements.client.ts
+++ b/src/runtime/customElements.client.ts
@@ -1,6 +1,8 @@
 import { defineCustomElements } from '@ionic/pwa-elements/loader'
 import { defineNuxtPlugin } from '#imports'
 
-export default defineNuxtPlugin(() => {
-  defineCustomElements(window)
+export default defineNuxtPlugin(nuxtApp => {
+  nuxtApp.hook('app:mounted', () => {
+    defineCustomElements(window)
+  })
 })


### PR DESCRIPTION
My first try at implementing [PWA Elements](https://capacitorjs.com/docs/web/pwa-elements), currently doesn't work
Since original capacitor documentation doesn't mention anything about Vue specifically, I figured it might be just the matter about executing `defineCustomElements(window)` once vue app is ready, for which I chose client plugin.

However I'm plagued by errors, as seen in the image below. Tried to debug them, but after trying can't figure out what might be wrong. Before this I also tried registering `setupCustomComponents` function with code similar to this plugin as a callback to certain hook, however I couldn't find suitable one from the [list](https://github.com/nuxt/framework/blob/8c2c80e43e80cd8f1c4246d7563214fa695a3e98/packages/schema/src/types/hooks.ts) that executes at the time where `window` is defined. @danielroe some of your input would be greatly appreciated 👍🏽 

![Errors image](https://user-images.githubusercontent.com/43365376/177006051-52107909-141b-449a-96b2-560c0b84fb8e.png)
