### PR TITLE
docs: fix outdated `app.vue` template link

### DIFF
--- a/docs/content/2.getting-started.md
+++ b/docs/content/2.getting-started.md
@@ -33,7 +33,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Finally, either remove your `app.vue` file or replace it with a custom one (starting with [this template](/usage#advanced)).
+Finally, either remove your `app.vue` file or replace it with a custom one (starting with [this template](/features#advanced)).
 
 You're good to go!
 


### PR DESCRIPTION
The `usage` page was updated to `features` in #27.