### PR TITLE
docs(getting-started): delete defineNuxtConfig import

### DIFF
--- a/docs/content/2.getting-started.md
+++ b/docs/content/2.getting-started.md
@@ -26,8 +26,6 @@ pnpm install nuxt-ionic -D
 Then add the module to your Nuxt configuration:
 
 ```js{}[nuxt.config]
-import { defineNuxtConfig } from 'nuxt'
-
 export default defineNuxtConfig({
   modules: ['nuxt-ionic']
 })
@@ -64,8 +62,6 @@ Find out more about how to use Capacitor with Ionic at https://capacitorjs.com/d
 While not required, you can configure the features that are enabled:
 
 ```js
-import { defineNuxtConfig } from 'nuxt'
-
 export default defineNuxtConfig({
   modules: ['nuxt-ionic'],
   ionic: {


### PR DESCRIPTION
delete defineNuxtConfig import as it's no needed since nuxt 3.0.0-rc.11 release